### PR TITLE
Fix launcher operation on macOS

### DIFF
--- a/fa_paths.py
+++ b/fa_paths.py
@@ -16,7 +16,7 @@ else:
 
 MY_CONFIG_DIR = os.path.dirname(MY_BIN)    
 
-MAC="Darwin"
+MAC="darwin"
 WIN="win32"
 LIN="linux"
 
@@ -109,6 +109,8 @@ factorio_replacements={
     '__PATH__executable__': os.path.dirname(BIN),
     '__PATH__system-read-data__': os.path.join(os.path.dirname(BIN),'..','..','data')
     }
+if sys.platform == MAC:
+    factorio_replacements['__PATH__system-read-data__'] = os.path.join(os.path.dirname(BIN),'..','data')
 
 def proccess(path):
     for k,v in factorio_replacements.items():

--- a/update_factorio.py
+++ b/update_factorio.py
@@ -18,7 +18,7 @@ debug=False
 
 download_package_map = {
     "win32":"win64-manual",
-    "Darwin":"osx",
+    "darwin":"osx",
     "linux":"linux64"
     }
 download_package = download_package_map[platform]


### PR DESCRIPTION
1. Corrected the macOS platform identifier in `fa_paths.py` and `update_factorio.py` from "Darwin" to "darwin" to match Python's `sys.platform` value, fixing a case sensitivity issue that prevented correct platform detection.
2. Added macOS-specific path correction in `fa_paths.py` to ensure proper data directory access, addressing a path resolution issue on macOS systems.